### PR TITLE
Patch to allow Darwin builds on releases before Yosemite/ios8

### DIFF
--- a/recipe/0002-Darwin-allow-build-on-releases-before-Yosemite-iOS8.patch
+++ b/recipe/0002-Darwin-allow-build-on-releases-before-Yosemite-iOS8.patch
@@ -1,0 +1,56 @@
+From cef404f1e7a598166cbc2fd2e0048f7e2d752ad5 Mon Sep 17 00:00:00 2001
+From: David Carlier <devnexen@gmail.com>
+Date: Tue, 24 Aug 2021 22:40:14 +0100
+Subject: [PATCH] Darwin platform allows to build on releases before
+ Yosemite/ios 8.
+
+issue #16407 #16408
+---
+ crypto/rand/rand_unix.c |  5 +----
+ include/crypto/rand.h   | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/rand/rand_unix.c b/crypto/rand/rand_unix.c
+index 43f1069d151d..0f4525106af7 100644
+--- a/crypto/rand/rand_unix.c
++++ b/crypto/rand/rand_unix.c
+@@ -34,9 +34,6 @@
+ #if defined(__OpenBSD__)
+ # include <sys/param.h>
+ #endif
+-#if defined(__APPLE__)
+-# include <CommonCrypto/CommonRandom.h>
+-#endif
+
+ #if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
+ # include <sys/types.h>
+@@ -381,7 +378,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
+         if (errno != ENOSYS)
+             return -1;
+     }
+-#  elif defined(__APPLE__)
++#  elif defined(OPENSSL_APPLE_CRYPTO_RANDOM)
+     if (CCRandomGenerateBytes(buf, buflen) == kCCSuccess)
+ 	    return (ssize_t)buflen;
+
+diff --git a/include/crypto/rand.h b/include/crypto/rand.h
+index 5350d3a93119..674f840fd13c 100644
+--- a/include/crypto/rand.h
++++ b/include/crypto/rand.h
+@@ -20,6 +20,16 @@
+
+ # include <openssl/rand.h>
+
++# if defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM)
++#  include <Availability.h>
++#  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101000) || \
++     (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000)
++#   define OPENSSL_APPLE_CRYPTO_RANDOM 1
++#   include <CommonCrypto/CommonCryptoError.h>
++#   include <CommonCrypto/CommonRandom.h>
++#  endif
++# endif
++
+ /* forward declaration */
+ typedef struct rand_pool_st RAND_POOL;
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,9 @@ source:
   sha256: 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
   patches:
     - 0001-Don-t-use-USE_BCRYPTGENRANDOM-for-VS-older-than-2015.patch
+    # 9/2/2021 PJY: Patch 0002 can lilkely be removed in the next release after 1.1.1l.
+    # The change was merged one day after 1.1.1l was released.
+    - 0002-Darwin-allow-build-on-releases-before-Yosemite-iOS8.patch   # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
`openssl-1.1.1l` was [released](https://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1l) on Aug 24, 2021.

A breaking change was found for OSX/Darwin builds later that day, and [a fix was merged for it](https://github.com/openssl/openssl/pull/16409) on Aug 25, 2021. This fix is not yet in any official release, so I created a patch:

`0002-Darwin-allow-build-on-releases-before-Yosemite-iOS8.patch`

which incorporates [the fix](https://github.com/openssl/openssl/commit/cef404f1e7a598166cbc2fd2e0048f7e2d752ad5.patch) into this recipe.

Before applying the patch, the build was breaking on OSX-64. After applying this patch, the recipe builds successfully.