### PR TITLE
openssl 1.1.1m

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -80,6 +80,7 @@ if [[ "${HOST}" == "${BUILD}" ]]; then
   make test > testsuite.log 2>&1 || true
   if ! cat testsuite.log | grep -i "all tests successful"; then
     echo "Testsuite failed!  See $(pwd)/testsuite.log for more info."
+    cat $(pwd)/testsuite.log
     exit 1
   fi
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,7 +41,6 @@ if [[ ${_BASE_CC} == *-* ]]; then
       ;;
     *darwin-arm64*)
       _CONFIG_OPTS+=(darwin64-arm64-cc)
-      CFLAGS="${CFLAGS} -Wa"
       ;;
   esac
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -77,7 +77,7 @@ rm test/recipes/04-test_err.t
 # "ALL TESTS SUCCESSFUL."
 # .. it exits with a failure code.
 if [[ "${HOST}" == "${BUILD}" ]]; then
-  make test > testsuite.log 2>&1 || true
+  make test VF=1 > testsuite.log 2>&1 || true
   if ! cat testsuite.log | grep -i "all tests successful"; then
     echo "Testsuite failed!  See $(pwd)/testsuite.log for more info."
     cat $(pwd)/testsuite.log

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,7 +36,7 @@ if [[ ${_BASE_CC} == *-* ]]; then
       _CONFIG_OPTS+=(linux64-s390x)
       CFLAGS="${CFLAGS} -Wa,--noexecstack"
       ;;
-    *darwin-arm64*)
+    *darwin-arm64*|*arm64-*-darwin*)
       _CONFIG_OPTS+=(darwin64-arm64-cc)
       ;;
     *darwin*)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,6 +39,10 @@ if [[ ${_BASE_CC} == *-* ]]; then
     *darwin*)
       _CONFIG_OPTS+=(darwin64-x86_64-cc)
       ;;
+    *darwin-arm64*)
+      _CONFIG_OPTS+=(darwin64-arm64-cc)
+      CFLAGS="${CFLAGS} -Wa"
+      ;;
   esac
 else
   if [[ $(uname) == Darwin ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -77,7 +77,8 @@ rm test/recipes/04-test_err.t
 # "ALL TESTS SUCCESSFUL."
 # .. it exits with a failure code.
 if [[ "${HOST}" == "${BUILD}" ]]; then
-  make test VF=1 > testsuite.log 2>&1 || true
+  # Using verbosity on failed (sub-)tests only VF=1
+  make test V=1 > testsuite.log 2>&1 || true
   if ! cat testsuite.log | grep -i "all tests successful"; then
     echo "Testsuite failed!  See $(pwd)/testsuite.log for more info."
     cat $(pwd)/testsuite.log

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,11 +36,11 @@ if [[ ${_BASE_CC} == *-* ]]; then
       _CONFIG_OPTS+=(linux64-s390x)
       CFLAGS="${CFLAGS} -Wa,--noexecstack"
       ;;
-    *darwin*)
-      _CONFIG_OPTS+=(darwin64-x86_64-cc)
-      ;;
     *darwin-arm64*)
       _CONFIG_OPTS+=(darwin64-arm64-cc)
+      ;;
+    *darwin*)
+      _CONFIG_OPTS+=(darwin64-x86_64-cc)
       ;;
   esac
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,6 @@ source:
   sha256: f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
   patches:
     - 0001-Don-t-use-USE_BCRYPTGENRANDOM-for-VS-older-than-2015.patch
-    # 9/2/2021 PJY: Patch 0002 can lilkely be removed in the next release after 1.1.1l.
-    # The change was merged one day after 1.1.1l was released.
-    - 0002-Darwin-allow-build-on-releases-before-Yosemite-iOS8.patch   # [osx]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1l" %}
+{% set version = "1.1.1m" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: http://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
+  sha256: f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
   patches:
     - 0001-Don-t-use-USE_BCRYPTGENRANDOM-for-VS-older-than-2015.patch
     # 9/2/2021 PJY: Patch 0002 can lilkely be removed in the next release after 1.1.1l.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
   requires:
     - certifi  # [win]
     - python 3.7  # [not (osx and arm64)]
-    - python 3.8  # [osx and arm64]
+    - python 3.9  # [osx and arm64]
     - six
   commands:
     - copy NUL checksum.txt        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,8 @@ requirements:
 
 test:
   requires:
-    - python 3.7
+    - python 3.7  # [not (osx and arm64)]
+    - python 3.8  # [osx and arm64]
     - six
   commands:
     - copy NUL checksum.txt        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
   requires:
     - certifi  # [win]
     - python 3.7  # [not (osx and arm64)]
-    - python 3.9  # [osx and arm64]
+    - python 3.8  # [osx and arm64]
     - six
   commands:
     - copy NUL checksum.txt        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,8 @@ test:
     - copy NUL checksum.txt        # [win]
     - touch checksum.txt           # [unix]
     - openssl sha256 checksum.txt
-    - python -c "from six.moves import urllib; urllib.request.urlopen('https://pypi.org')"
-
+    - python -c "from six.moves import urllib; urllib.request.urlopen('https://pypi.org')"  # [unix]
+    - python -c "import certifi; import ssl; import urllib.request as urlrq; urlrq.urlopen('https://pypi.org', context=ssl.create_default_context(cafile=certifi.where()))"  # [win]
 
 about:
   home: http://www.openssl.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
 
 test:
   requires:
+    - certifi  # [win]
     - python 3.7  # [not (osx and arm64)]
     - python 3.8  # [osx and arm64]
     - six


### PR DESCRIPTION
Update openssl to 1.1.1m

Actions:
1. Fix python in `test/requires`
2. Add `certifi  # [win]` in `test/reuires`
3. Fix calling `certifi` in `test/commands` on `win` to fix a `urllib.error.URLError`
4. Remove an old patch
5. Use verbosity `V=1` for `testsuite.log`
6. Fix an issue with failed tests on `arm64`