### PR TITLE
OpenSSL 1.1.1o

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,7 +14,8 @@ REM write permissions to limit the risk of non-privileged users exploiting
 REM OpenSSL's engines feature to perform arbitrary code execution attacks
 REM against applications that load the OpenSSL DLLs.
 REM
-%LIBRARY_BIN%\perl configure %OSSL_CONFIGURE% ^
+set PERL=%BUILD_PREFIX%\Library\bin\perl
+%BUILD_PREFIX%\Library\bin\perl configure %OSSL_CONFIGURE% ^
     --prefix=%LIBRARY_PREFIX% ^
     --openssldir="%CommonProgramFiles%\ssl"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PERL=${PREFIX}/bin/perl
+PERL="${BUILD_PREFIX}/bin/perl"
 declare -a _CONFIG_OPTS
 _CONFIG_OPTS+=(--prefix=${PREFIX})
 _CONFIG_OPTS+=(--libdir=lib)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,10 +36,6 @@ requirements:
     - make               # [unix]
     - patch              # [unix]
     - m2-patch           # [win]
-
-  host:
-    # technically a build tool, but the windows makefile really wants to find it in the host env.
-    #    easier to do this than carry a patch.
     - perl
   run:
     - ca-certificates

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1n" %}
+{% set version = "1.1.1o" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: 40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
+  sha256: 9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
 
 build:
   number: 0


### PR DESCRIPTION
Upgrade to latest version from 1.1.1n to 1.1.1o. Changelog at

    https://www.openssl.org/news/cl111.txt

Fixes CVE-2022-1292.