### PR TITLE
OpenSSL 1.1.1p

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1o" %}
+{% set version = "1.1.1p" %}
 
 package:
   name: {{ name|lower }}
@@ -8,8 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: 9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
-
+  sha256: bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f 
 build:
   number: 0
   no_link: lib/libcrypto.so.1.1        # [linux]


### PR DESCRIPTION
The `1.1.1p` release fixes [CVE-2022-2068](https://www.openssl.org/news/vulnerabilities.html#CVE-2022-2068); no other major changes made.

- [x] Verified local build
- [x] Verified home page URL
- [x] Verified license identifier in SPDX
- [x] Verified package summary
- [x] Verified `dev_url`
- [x] Verified `doc_url`

 

