### PR TITLE
openssl 1.1.1q

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler_version:        # [linux or osx]
+  - 7.5.0                  # [linux and not (s390x or aarch64 or ppc64le)]
+  - 7.3.0                  # [linux and ppc64le]
+  - 7.5.0                  # [linux and s390x]
+  - 10.2.0                 # [linux and aarch64]
+  - 12                     # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1p" %}
+{% set version = "1.1.1q" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f 
+  sha256: d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca 
 build:
   number: 0
   no_link: lib/libcrypto.so.1.1        # [linux]


### PR DESCRIPTION
Changelog: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1q/CHANGES
```
 Changes between 1.1.1p and 1.1.1q [5 Jul 2022]

  *) AES OCB mode for 32-bit x86 platforms using the AES-NI assembly optimised
     implementation would not encrypt the entirety of the data under some
     circumstances.  This could reveal sixteen bytes of data that was
     preexisting in the memory that wasn't written.  In the special case of
     "in place" encryption, sixteen bytes of the plaintext would be revealed.

     Since OpenSSL does not support OCB based cipher suites for TLS and DTLS,
     they are both unaffected.
     (CVE-2022-2097)
```

No actions