### PR TITLE
1.1.1q rebuild for s390x

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,9 +28,16 @@ if [[ ${_BASE_CC} == *-* ]]; then
       _CONFIG_OPTS+=(linux-ppc64le)
       CFLAGS="${CFLAGS} -Wa,--noexecstack"
       ;;
+    # Optimized s390x builds must use -fno-merge-constants.
+    # Without this, a string ("private") in the nid_objs table
+    # (obj_dat.c) will vanish when libcrypto.so is built.
+    # This is currently assumed to be a bug in the -fmerge-constants
+    # optimization for this architecture.
+    # This issue prevents the OBJ_sn2nid function from ever finding
+    # prime256v1, rendering it unusable as an ecparam.
     *s390x-*linux*)
       _CONFIG_OPTS+=(linux64-s390x)
-      CFLAGS="${CFLAGS} -Wa,--noexecstack"
+      CFLAGS="${CFLAGS} -Wa,--noexecstack -fno-merge-constants"
       ;;
     *darwin-arm64*|*arm64-*-darwin*)
       _CONFIG_OPTS+=(darwin64-arm64-cc)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,10 +57,18 @@ about:
   home: https://www.openssl.org/
   license_file: LICENSE
   license: OpenSSL
+  license_url: https://www.openssl.org/source/license.html
   license_family: Apache
   summary: OpenSSL is an open-source implementation of the SSL and TLS protocols
+  description: |
+    OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit
+    for the Transport Layer Security (TLS) protocol formerly known as the
+    Secure Sockets Layer (SSL) protocol. The protocol implementation is based
+    on a full-strength general purpose cryptographic library, which can also
+    be used stand-alone.
   dev_url: https://github.com/openssl/openssl
   doc_url: https://www.openssl.org/docs/man1.1.1/
+  doc_source_url: https://github.com/openssl/openssl/tree/OpenSSL_1_1_1-stable/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ test:
     - copy NUL checksum.txt        # [win]
     - touch checksum.txt           # [unix]
     - openssl sha256 checksum.txt
+    - openssl ecparam -name prime256v1
     - python -c "from six.moves import urllib; urllib.request.urlopen('https://pypi.org')"  # [unix]
     - python -c "import certifi; import ssl; import urllib.request as urlrq; urlrq.urlopen('https://pypi.org', context=ssl.create_default_context(cafile=certifi.where()))"  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,9 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca 
+  sha256: d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
 build:
-  number: 0
+  number: 1
   no_link: lib/libcrypto.so.1.1        # [linux]
   no_link: lib/libcrypto.1.1.dylib     # [osx]
   has_prefix_files:                      # [unix]


### PR DESCRIPTION
## Changes
- Added `-fno-merge-constants` to `build.sh` for `s390x`
- Added `ecparam` test for `prime256v1`
- Added `description`, `license_url`, and `doc_source_url` to `about` section

# Notes

When building `openssl` for `s390x`, optimized builds by default are suffering from an issue where a string is left out of `libcrypto.so`. This is presumed to be a bug when `-fmerge-constants` is used on this platform. This issue prevents the `OBJ_sn2nid` function from ever finding `prime256v1`, rendering it unusable as an `ecparam`. Disabling this optimization with `-fno-merge-constants` resolves the issue.

This fix should allow the `openssl` CLI to function as expected with `prime256v1` (and `secp256r1`) `ecparam`s. It should also allow all tests in the `cryptography` package to be re-enabled for `s390x`.
