### PR TITLE
openssl 1.1.1s

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1q" %}
+{% set version = "1.1.1s" %}
 
 package:
   name: {{ name|lower }}
@@ -8,9 +8,9 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
+  sha256: c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa
 build:
-  number: 1
+  number: 0
   no_link: lib/libcrypto.so.1.1        # [linux]
   no_link: lib/libcrypto.1.1.dylib     # [osx]
   has_prefix_files:                      # [unix]


### PR DESCRIPTION
## Changes

- Updated from `1.1.1q` to `1.1.1s`.

## Links

- Changelog: https://www.openssl.org/news/cl111.txt
- GitHub: https://github.com/openssl/openssl/
- Changes: https://github.com/openssl/openssl/compare/OpenSSL_1_1_1q..OpenSSL_1_1_1s

## Notes

This release fixes a regression that occurred in `1.1.1r`. `1.1.1r` contained bugfixes and performance enhancements.

The `openssl` 1.x series is **not** affected by the recent `CVE-2022-3786` and `CVE-2022-3602` CVEs.