### PR TITLE
v1.1.1t

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,6 @@ about:
   home: https://www.openssl.org/
   license_file: LICENSE
   license: OpenSSL
-  license_url: https://www.openssl.org/source/license.html
   license_family: Apache
   summary: OpenSSL is an open-source implementation of the SSL and TLS protocols
   description: |
@@ -68,7 +67,6 @@ about:
     be used stand-alone.
   dev_url: https://github.com/openssl/openssl
   doc_url: https://www.openssl.org/docs/man1.1.1/
-  doc_source_url: https://github.com/openssl/openssl/tree/OpenSSL_1_1_1-stable/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,6 @@ requirements:
     - {{ compiler('c') }}
     - nasm               # [win]
     - make               # [unix]
-    - patch              # [unix]
-    - m2-patch           # [win]
     - perl
   run:
     - ca-certificates

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1s" %}
+{% set version = "1.1.1t" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa
+  sha256: 8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b
 build:
   number: 0
   no_link: lib/libcrypto.so.1.1        # [linux]


### PR DESCRIPTION
# OpenSSL v1.1.1t

jira: https://anaconda.atlassian.net/browse/PKG-1107
release notes: https://www.openssl.org/news/openssl-1.1.1-notes.html

## Changes
- Bump version and SHA

## Notes
- Fixes the following CVEs
  - CVE-2023-0286
  - CVE-2023-0215
  - CVE-2022-4450
  - CVE-2022-4304