### PR TITLE
Updating version and hash.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "1.1.1u" %}
+{% set version = "1.1.1v" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
+  sha256: d6697e2871e77238460402e9362d47d18382b15ef9f246aba6c7bd780d38a6b0
 build:
   number: 0
   no_link: lib/libcrypto.so.1.1        # [linux]


### PR DESCRIPTION
- Updated version and hash

No big changes in upstream:
https://github.com/openssl/openssl/compare/OpenSSL_1_1_1u..OpenSSL_1_1_1v