### PR TITLE
Updating version and hash.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.0.9" %}
+{% set version = "3.0.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90
+  sha256: 1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]


### PR DESCRIPTION
Log:
- Just updated version and hash.
- Only significant changes were some FIPS things which we do not build in.

Upstream diff:
https://github.com/openssl/openssl/compare/openssl-3.0.9..openssl-3.0.10