### PR TITLE
Set the SSL_CERT_FILE environment variables via an activation script on Windows

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,4 +1,4 @@
 if "%SSL_CERT_FILE%"=="" (
-    set SSL_CERT_FILE="%LIBRARY_PREFIX%\ssl\cacert.pem"
+    set SSL_CERT_FILE="%CONDA_PREFIX%\Library\ssl\cacert.pem"
     set __CONDA_OPENSLL_CERT_FILE_SET="1"
 )

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,0 +1,4 @@
+if "%SSL_CERT_FILE%"=="" (
+    set SSL_CERT_FILE="%LIBRARY_PREFIX%\ssl\cacert.pem"
+    set __CONDA_OPENSLL_CERT_FILE_SET="1"
+)

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,4 +1,4 @@
 if "%SSL_CERT_FILE%"=="" (
-    set SSL_CERT_FILE="%CONDA_PREFIX%\Library\ssl\cacert.pem"
+    set SSL_CERT_FILE=%CONDA_PREFIX%\Library\ssl\cacert.pem
     set __CONDA_OPENSLL_CERT_FILE_SET="1"
 )

--- a/recipe/activate.ps1
+++ b/recipe/activate.ps1
@@ -1,0 +1,4 @@
+if (-not $Env:SSL_CERT_FILE) {
+    $Env:SSL_CERT_FILE = "$Env:CONDA_PREFIX\Library\ssl\cacert.pem"
+    $Env:__CONDA_OPENSLL_CERT_FILE_SET = "1"
+}

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,4 +1,4 @@
 if [[ "$SSL_CERT_FILE" == "" ]]; then
-    export SSL_CERT_FILE="${LIBRARY_PREFIX}\\ssl\\cacert.pem"
+    export SSL_CERT_FILE="${CONDA_PREFIX}\\Library\ssl\\cacert.pem"
     export __CONDA_OPENSLL_CERT_FILE_SET="1"
 fi

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,4 @@
+if [[ "$SSL_CERT_FILE" == "" ]]; then
+    export SSL_CERT_FILE="${LIBRARY_PREFIX}\\ssl\\cacert.pem"
+    export __CONDA_OPENSLL_CERT_FILE_SET="1"
+fi

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -73,6 +73,7 @@ rem xcopy /S inc32\openssl\*.* %LIBRARY_INC%\openssl\
 for %%F in (activate deactivate) DO (
     if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
     copy "%RECIPE_DIR%\%%F.bat" "%PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat"
+    copy "%RECIPE_DIR%\%%F.ps1" "%PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.ps1"
     :: Copy unix shell activation scripts, needed by Windows Bash users
     copy "%RECIPE_DIR%\%%F.sh" "%PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh"
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -72,7 +72,7 @@ rem xcopy /S inc32\openssl\*.* %LIBRARY_INC%\openssl\
 :: This will allow them to be run on environment activation.
 for %%F in (activate deactivate) DO (
     if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
-    copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    copy "%RECIPE_DIR%\%%F.bat" "%PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat"
     :: Copy unix shell activation scripts, needed by Windows Bash users
-    copy %RECIPE_DIR%\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
+    copy "%RECIPE_DIR%\%%F.sh" "%PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh"
 )

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,4 @@
+if "%__CONDA_OPENSLL_CERT_FILE_SET%" == "1" (
+    set SSL_CERT_FILE=
+    set __CONDA_OPENSLL_CERT_FILE_SET=
+)

--- a/recipe/deactivate.ps1
+++ b/recipe/deactivate.ps1
@@ -1,4 +1,4 @@
 if ($Env:__CONDA_OPENSLL_CERT_FILE_SET -eq "1") {
-    Remove-Item -Path Env:\CERT_FILE_SET
-    Remote-Item -Path Env:\__CONDA_OPENSLL_CERT_FILE_SET
+    Remove-Item -Path Env:\SSL_CERT_FILE
+    Remove-Item -Path Env:\__CONDA_OPENSLL_CERT_FILE_SET
 }

--- a/recipe/deactivate.ps1
+++ b/recipe/deactivate.ps1
@@ -1,0 +1,4 @@
+if ($Env:__CONDA_OPENSLL_CERT_FILE_SET -eq "1") {
+    Remove-Item -Path Env:\CERT_FILE_SET
+    Remote-Item -Path Env:\__CONDA_OPENSLL_CERT_FILE_SET
+}

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,4 +1,4 @@
 if [[ "$__CONDA_OPENSLL_CERT_FILE_SET" == "1" ]]; then
     unset SSL_CERT_FILE
-    unset
+    unset __CONDA_OPENSLL_CERT_FILE_SET
 fi

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,4 @@
+if [[ "$__CONDA_OPENSLL_CERT_FILE_SET" == "1" ]]; then
+    unset SSL_CERT_FILE
+    unset
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ test:
     - touch checksum.txt           # [unix]
     - openssl sha256 checksum.txt
     - openssl ecparam -name prime256v1
+    - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
+    - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
     - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
   sha256: 1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323
 build:
-  number: 0
+  number: 1
   no_link: lib/libcrypto.so.3.0        # [linux]
   no_link: lib/libcrypto.3.0.dylib     # [osx]
   has_prefix_files:                      # [unix]
@@ -39,16 +39,13 @@ requirements:
 
 test:
   requires:
-    - certifi  # [win]
     - python 3.8
-    - six
   commands:
     - copy NUL checksum.txt        # [win]
     - touch checksum.txt           # [unix]
     - openssl sha256 checksum.txt
     - openssl ecparam -name prime256v1
-    - python -c "from six.moves import urllib; urllib.request.urlopen('https://pypi.org')"  # [unix]
-    - python -c "import certifi; import ssl; import urllib.request as urlrq; urlrq.urlopen('https://pypi.org', context=ssl.create_default_context(cafile=certifi.where()))"  # [win]
+    - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
 
 about:
   home: https://www.openssl.org/


### PR DESCRIPTION
Set the `SSL_CERT_FILE` environment variable via an activation script on Windows to make sure Python can do HTTPS requests by default without requiring `certifi`.

Note that the activation scripts will only be bundled on Windows. Also note that we will only set `SSL_CERT_FILE` if not not yet set. If a customer has set its own `SSL_CERT_FILE`, we don't want to override it to something else.

For more context, when compiling OpenSSL, we can pass the `--openssldir` flag. The openssl dir is the directory where
the OpenSSL config can be found. The path given to `--openssldir` gets hardcoded in the libraries.

On Linux and macOS, we set it to `$PREFIX/ssl` (implicitly by setting `--prefix`) and when the package is installed in
an environment, conda takes care of replacing the the prefix in the DSOs with the path to the environment where the package is being installed. `$PREFIX/ssl` is populated with a file named `cacert.pem` which comes from the `ca-certificates` package. So when we use the openssl package, it uses this file.

But on Windows, conda doesn't do any DSO prefix replacement. So we hardcode the value to `%CommonProgramFiles%\ssl`
for security reasons (see https://github.com/AnacondaRecipes/openssl-feedstock/blob/67f77d1e8dab82ab3399431d9ec9853e5141785a/recipe/bld.bat#L7-L15
and https://anaconda.atlassian.net/browse/DSNC-2391). Because of that, openssl doesn't know anything about CA root certs and calling `urllib.request.urlopen` in python on Windows will result in an error like
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]  
certificate verify failed: unable to get local issuer certificate   
(_ssl.c:1129)
```

This is because Python doesn't use the Windows system truststore and since `%CommonProgramFiles%\ssl` likely doesn't exist, then it fails.

Setting `$SSL_CERT_FILE` avoids this problem. It makes it consistent across all platforms.