### PR TITLE
Reduce (de)activate.bat verbosity

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,3 +1,4 @@
+@echo off
 if "%SSL_CERT_FILE%"=="" (
     set SSL_CERT_FILE=%CONDA_PREFIX%\Library\ssl\cacert.pem
     set __CONDA_OPENSLL_CERT_FILE_SET="1"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,4 +1,4 @@
-if [[ "$SSL_CERT_FILE" == "" ]]; then
+if [[ "${SSL_CERT_FILE:-}" == "" ]]; then
     export SSL_CERT_FILE="${CONDA_PREFIX}\\Library\ssl\\cacert.pem"
     export __CONDA_OPENSLL_CERT_FILE_SET="1"
 fi

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,3 +1,4 @@
+@echo off
 if "%__CONDA_OPENSLL_CERT_FILE_SET%" == "1" (
     set SSL_CERT_FILE=
     set __CONDA_OPENSLL_CERT_FILE_SET=

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,4 +1,4 @@
-if [[ "$__CONDA_OPENSLL_CERT_FILE_SET" == "1" ]]; then
+if [[ "${__CONDA_OPENSLL_CERT_FILE_SET:-}" == "1" ]]; then
     unset SSL_CERT_FILE
     unset __CONDA_OPENSLL_CERT_FILE_SET
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
   sha256: 1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323
 build:
-  number: 1
+  number: 2
   no_link: lib/libcrypto.so.3.0        # [linux]
   no_link: lib/libcrypto.3.0.dylib     # [osx]
   has_prefix_files:                      # [unix]


### PR DESCRIPTION
Set `@echo off` so (de)activating environments with OpenSSL in cmd doesn't spew the logic all over stdout.