### PR TITLE
Version 3.0.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.0.12" %}
+{% set version = "3.0.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61
+  sha256: 88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]


### PR DESCRIPTION
openssl 3.0.13

**Destination channel:** defaults

### Links

- [{ticket_number}]([PKG-3982](https://anaconda.atlassian.net/browse/PKG-3982)) 
- [Upstream repository](https://github.com/openssl/openssl)
- [Upstream changelog/diff](https://github.com/openssl/openssl/blob/master/CHANGES.md)

### Explanation of changes:

- Bump to 3.0.13


[PKG-3982]: https://anaconda.atlassian.net/browse/PKG-3982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ