### PR TITLE
Updated to 3.0.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "openssl" %}
-{% set version = "3.0.14" %}
+{% set version = "3.0.15" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz
-  sha256: eeca035d4dd4e84fc25846d952da6297484afa0650a6f84c682e39df3a4123ca
+#  url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz  # TODO: Revert to this link once the package is on the website. https://openssl-library.org/source/old/3.0/index.html
+  url: https://github.com/openssl/openssl/releases/download/openssl-{{ version }}/openssl-{{ version }}.tar.gz
+  sha256: 23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-#  url: https://www.openssl.org/source/{{ name }}-{{ version }}.tar.gz  # TODO: Revert to this link once the package is on the website. https://openssl-library.org/source/old/3.0/index.html
   url: https://github.com/openssl/openssl/releases/download/openssl-{{ version }}/openssl-{{ version }}.tar.gz
   sha256: 23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
 build:


### PR DESCRIPTION
openssl 3.0.15

**Destination channel:** defaults

### Links

- [PKG-5638](https://anaconda.atlassian.net/browse/PKG-5638) 
- [Upstream repository](https://github.com/openssl/openssl/tree/openssl-3.0.15)
- [Upstream changelog/diff](https://github.com/openssl/openssl/blob/openssl-3.0.15/CHANGES.md)


[PKG-5638]: https://anaconda.atlassian.net/browse/PKG-5638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ