### PR TITLE
PKG-12262-openssl-3.0.19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.0.18" %}
+{% set version = "3.0.19" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b
+  sha256: fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]
@@ -54,7 +54,7 @@ test:
     - pkg-config --print-errors --exact-version "{{ version }}" openssl
 
 about:
-  home: https://www.openssl.org/
+  home: https://www.openssl.org
   license_file: LICENSE.txt
   license: Apache-2.0
   license_family: Apache
@@ -66,7 +66,7 @@ about:
     on a full-strength general purpose cryptographic library, which can also
     be used stand-alone.
   dev_url: https://github.com/openssl/openssl
-  doc_url: https://www.openssl.org/docs/man3.0/
+  doc_url: https://www.openssl.org/docs/man3.0
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
openssl 3.0.19

- [PKG-12262](https://anaconda.atlassian.net/browse/PKG-12262)
- conda_forge: https://github.com/conda-forge/openssl-feedstock/pull/223/changes
- dev_url: https://github.com/openssl/openssl/tree/openssl-3.0.19
- changelog: https://github.com/openssl/openssl/blob/openssl-3.0.19/CHANGES.md#changes-between-3018-and-3019-27-jan-2026

## Explanation of changes

3.0.18 was impacted by CVE-2025-15467 and seven others with up to HIGH scores. Bumped version.

[PKG-12262]: https://anaconda.atlassian.net/browse/PKG-12262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ