### PR TITLE
PKG-9917-openssl-3.5

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,5 +1,5 @@
 @echo off
 if "%SSL_CERT_FILE%"=="" (
     set SSL_CERT_FILE=%CONDA_PREFIX%\Library\ssl\cacert.pem
-    set __CONDA_OPENSLL_CERT_FILE_SET="1"
+    set __CONDA_OPENSSL_CERT_FILE_SET="1"
 )

--- a/recipe/activate.ps1
+++ b/recipe/activate.ps1
@@ -1,4 +1,4 @@
 if (-not $Env:SSL_CERT_FILE) {
     $Env:SSL_CERT_FILE = "$Env:CONDA_PREFIX\Library\ssl\cacert.pem"
-    $Env:__CONDA_OPENSLL_CERT_FILE_SET = "1"
+    $Env:__CONDA_OPENSSL_CERT_FILE_SET = "1"
 }

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,4 +1,4 @@
 if [[ "${SSL_CERT_FILE:-}" == "" ]]; then
-    export SSL_CERT_FILE="${CONDA_PREFIX}\\Library\ssl\\cacert.pem"
-    export __CONDA_OPENSLL_CERT_FILE_SET="1"
+    export SSL_CERT_FILE="${CONDA_PREFIX}/ssl/cacert.pem"
+    export __CONDA_OPENSSL_CERT_FILE_SET="1"
 fi

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,18 +9,15 @@ if "%ARCH%"=="32" (
 
 REM Configure step
 REM
-REM Conda currently does not perform prefix replacement on Windows, so
-REM OPENSSLDIR cannot (reliably) be used to provide functionality such as a
-REM default configuration and standard CA certificates on a per-environment
-REM basis.  Given that, we set OPENSSLDIR to a location with extremely limited
-REM write permissions to limit the risk of non-privileged users exploiting
-REM OpenSSL's engines feature to perform arbitrary code execution attacks
-REM against applications that load the OpenSSL DLLs.
-REM
-REM On top of that, we also set the SSL_CERT_FILE environment variable
-REM via an activation script to point to the ca-certificates provided CA root file.
+REM We set OPENSSLDIR to a location with extremely limited write permissions
+REM (e.g. %%CommonProgramFiles%%\ssl) to limit the risk of non-privileged users
+REM exploiting OpenSSL's config/engines feature to perform arbitrary code execution
+REM (see e.g. CVE-2019-5443, CVE-2024-6975).  Per-environment config and CA certs
+REM are not provided via OPENSSLDIR; SSL_CERT_FILE is set via an activation script
+REM to point to the ca-certificates package CA root file.
+REM If that folder does not exist, OpenSSL still works (defaults + SSL_CERT_FILE).
 set PERL=%BUILD_PREFIX%\Library\bin\perl
-%BUILD_PREFIX%\Library\bin\perl configure %OSSL_CONFIGURE% ^
+%BUILD_PREFIX%\Library\bin\perl Configure %OSSL_CONFIGURE% ^
     --prefix=%LIBRARY_PREFIX% ^
     --openssldir="%CommonProgramFiles%\ssl" ^
     threads ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,27 +23,16 @@ set PERL=%BUILD_PREFIX%\Library\bin\perl
 %BUILD_PREFIX%\Library\bin\perl configure %OSSL_CONFIGURE% ^
     --prefix=%LIBRARY_PREFIX% ^
     --openssldir="%CommonProgramFiles%\ssl" ^
-    enable-legacy ^
-    no-fips ^
-    no-module ^
+    threads ^
     no-zlib ^
-    shared
+    enable-legacy ^
+    no-module ^
+    no-shared
 
 if errorlevel 1 exit 1
-
-REM Build step
-rem if "%ARCH%"=="64" (
-rem     ml64 -c -Foms\uptable.obj ms\uptable.asm
-rem     if errorlevel 1 exit 1
-rem )
 
 nmake
 if errorlevel 1 exit 1
-
-rem nmake -f ms\nt.mak
-rem if errorlevel 1 exit 1
-rem nmake -f ms\ntdll.mak
-rem if errorlevel 1 exit 1
 
 REM Testing step
 nmake test
@@ -58,28 +47,17 @@ REM configured OPENSSLDIR above makes these files non-functional.)
 nmake install_ssldirs OPENSSLDIR=%LIBRARY_PREFIX%\ssl
 if errorlevel 1 exit 1
 
-REM Install step
-rem copy out32dll\openssl.exe %PREFIX%\openssl.exe
-rem copy out32\ssleay32.lib %LIBRARY_LIB%\ssleay32_static.lib
-rem copy out32\libeay32.lib %LIBRARY_LIB%\libeay32_static.lib
-rem copy out32dll\ssleay32.lib %LIBRARY_LIB%\ssleay32.lib
-rem copy out32dll\libeay32.lib %LIBRARY_LIB%\libeay32.lib
-rem copy out32dll\ssleay32.dll %LIBRARY_BIN%\ssleay32.dll
-rem copy out32dll\libeay32.dll %LIBRARY_BIN%\libeay32.dll
-rem mkdir %LIBRARY_INC%\openssl
-rem xcopy /S inc32\openssl\*.* %LIBRARY_INC%\openssl\
-
 REM Add pkgconfig files: adapted from https://github.com/conda-forge/openssl-feedstock/pull/106
 :: install pkgconfig metadata (useful for downstream packages);
 :: adapted from inspecting the conda-forge .pc files for unix, as well as
 :: https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake
-mkdir %LIBRARY_PREFIX%\lib\pkgconfig
-for %%F in (openssl libssl libcrypto) DO (
-    echo prefix=%LIBRARY_PREFIX:\=/% > %%F.pc
-    type %RECIPE_DIR%\win_pkgconfig\%%F.pc.in >> %%F.pc
-    echo Version: %PKG_VERSION% >> %%F.pc
-    copy %%F.pc %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
-)
+@REM mkdir %LIBRARY_PREFIX%\lib\pkgconfig
+@REM for %%F in (openssl libssl libcrypto) DO (
+@REM     echo prefix=%LIBRARY_PREFIX:\=/% > %%F.pc
+@REM     type %RECIPE_DIR%\win_pkgconfig\%%F.pc.in >> %%F.pc
+@REM     echo Version: %PKG_VERSION% >> %%F.pc
+@REM     copy %%F.pc %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
+@REM )
 
 :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
 :: This will allow them to be run on environment activation.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -17,7 +17,7 @@ REM are not provided via OPENSSLDIR; SSL_CERT_FILE is set via an activation scri
 REM to point to the ca-certificates package CA root file.
 REM If that folder does not exist, OpenSSL still works (defaults + SSL_CERT_FILE).
 set PERL=%BUILD_PREFIX%\Library\bin\perl
-%BUILD_PREFIX%\Library\bin\perl Configure %OSSL_CONFIGURE% ^
+%BUILD_PREFIX%\Library\bin\perl configure %OSSL_CONFIGURE% ^
     --prefix=%LIBRARY_PREFIX% ^
     --openssldir="%CommonProgramFiles%\ssl" ^
     threads ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,8 +23,7 @@ set PERL=%BUILD_PREFIX%\Library\bin\perl
     threads ^
     no-zlib ^
     enable-legacy ^
-    no-module ^
-    no-shared
+    no-module
 
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,7 +23,8 @@ set PERL=%BUILD_PREFIX%\Library\bin\perl
     threads ^
     no-zlib ^
     enable-legacy ^
-    no-module
+    no-module ^
+    shared
 
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -28,6 +28,13 @@ set PERL=%BUILD_PREFIX%\Library\bin\perl
 
 if errorlevel 1 exit 1
 
+REM Specify in metadata where the packaging is coming from
+set "OPENSSL_VERSION_BUILD_METADATA=+anaconda"
+
+REM Dump configuration results
+%BUILD_PREFIX%\Library\bin\perl configdata.pm --dump
+if errorlevel 1 exit 1
+
 nmake
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -48,13 +48,13 @@ REM Add pkgconfig files: adapted from https://github.com/conda-forge/openssl-fee
 :: install pkgconfig metadata (useful for downstream packages);
 :: adapted from inspecting the conda-forge .pc files for unix, as well as
 :: https://github.com/microsoft/vcpkg/blob/master/ports/openssl/install-pc-files.cmake
-@REM mkdir %LIBRARY_PREFIX%\lib\pkgconfig
-@REM for %%F in (openssl libssl libcrypto) DO (
-@REM     echo prefix=%LIBRARY_PREFIX:\=/% > %%F.pc
-@REM     type %RECIPE_DIR%\win_pkgconfig\%%F.pc.in >> %%F.pc
-@REM     echo Version: %PKG_VERSION% >> %%F.pc
-@REM     copy %%F.pc %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
-@REM )
+mkdir %LIBRARY_PREFIX%\lib\pkgconfig
+for %%F in (openssl libssl libcrypto) DO (
+    echo prefix=%LIBRARY_PREFIX:\=/% > %%F.pc
+    type %RECIPE_DIR%\win_pkgconfig\%%F.pc.in >> %%F.pc
+    echo Version: %PKG_VERSION% >> %%F.pc
+    copy %%F.pc %LIBRARY_PREFIX%\lib\pkgconfig\%%F.pc
+)
 
 :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
 :: This will allow them to be run on environment activation.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -68,4 +68,4 @@ CC="${CC}" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
 
 make -j${CPU_COUNT}
 make test
-make install
+make install_sw install_ssldirs

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,78 +1,66 @@
 #!/bin/bash
 
+# Use perl from conda's env
 PERL="${BUILD_PREFIX}/bin/perl"
+
+# Array of options for the openssl configurator perl script
 declare -a _CONFIG_OPTS
+
+# Organize artifacts within conda file
 _CONFIG_OPTS+=(--prefix=${PREFIX})
 _CONFIG_OPTS+=(--libdir=lib)
-_CONFIG_OPTS+=(shared)
-_CONFIG_OPTS+=(threads)
-_CONFIG_OPTS+=(no-ssl2)     # broken, insecure protocol
-_CONFIG_OPTS+=(no-ssl3)     # broken, insecure protocol
-_CONFIG_OPTS+=(no-zlib)
-_CONFIG_OPTS+=(enable-legacy) # necessary to support some function in Python package cryptography
 
-_BASE_CC=$(basename "${CC}")
-if [[ ${_BASE_CC} == *-* ]]; then
-  # We are cross-compiling or using a specific compiler.
-  # do not allow config to make any guesses based on uname.
-  _CONFIGURATOR="perl ./Configure"
-  case ${_BASE_CC} in
-    x86_64-*linux*)
-      _CONFIG_OPTS+=(linux-x86_64)
-      CFLAGS="${CFLAGS} -Wa,--noexecstack"
-      ;;
-    aarch64-*-linux*)
-      _CONFIG_OPTS+=(linux-aarch64)
-      CFLAGS="${CFLAGS} -Wa,--noexecstack"
-      ;;
-    *darwin-arm64*|*arm64-*-darwin*)
-      _CONFIG_OPTS+=(darwin64-arm64-cc)
-      ;;
-  esac
-else
-  # Use config, which is a config.guess-like wrapper around Configure
-  _CONFIGURATOR=./config
+# Create a library that is suitable for multithreaded applications
+_CONFIG_OPTS+=(threads)
+
+# Don't compile support for zlib compression.
+# Using compression is not recommended for security reasons.
+# Ref: https://nvd.nist.gov/vuln/detail/CVE-2012-4929
+_CONFIG_OPTS+=(no-zlib)
+
+# Necessary to support some function in Python package cryptography.
+# Enabled by default anyway, keeping for explicitness
+_CONFIG_OPTS+=(enable-legacy)
+
+# Engines are deprecated from 3.0. Ref: https://github.com/openssl/openssl/blob/openssl-3.5.5/README-ENGINES.md
+# With no-module, the legacy provider is built into libcrypto.
+_CONFIG_OPTS+=(no-module)
+
+# CF provides shared libraries in a separate output.
+# Since we don't do it, optimize build process by disabling it.
+_CONFIG_OPTS+=(no-shared)
+
+# In previous versions of build.sh, no-ssl2 and no-ssl3 were also added.
+# However, ssl2 was removed in OpenSSL 1.1.0 and ssl3 is disabled by default.
+# CF ignores 'fips' but it's off by default anyway.
+
+if [[ "$target_platform" = "linux-"* ]]; then
+  # KTLS is an optimization feature for Linux (and FreeBSD)
+  _CONFIG_OPTS+=(enable-ktls)
 fi
 
-CC=${CC}" ${CPPFLAGS} ${CFLAGS}" \
-  ${_CONFIGURATOR} ${_CONFIG_OPTS[@]} ${LDFLAGS}
+# Do not allow config to make any guesses based on uname.
+# Target names can be found in upstream at Configurations/10-main.conf
+_CONFIGURATOR="perl ./Configure"
+case "$target_platform" in
+  linux-64)
+    _CONFIG_OPTS+=(linux-x86_64)
+    CFLAGS="${CFLAGS} -Wa,--noexecstack"
+    ;;
+  linux-aarch64)
+    _CONFIG_OPTS+=(linux-aarch64)
+    CFLAGS="${CFLAGS} -Wa,--noexecstack"
+    ;;
+  osx-arm64)
+    _CONFIG_OPTS+=(darwin64-arm64-cc)
+    ;;
+esac
 
-# This is not working yet. It may be important if we want to perform a parallel build
-# as enabled by openssl-1.0.2d-parallel-build.patch where the dependency info is old.
-# makedepend is a tool from xorg, but it seems to be little more than a wrapper for
-# '${CC} -M', so my plan is to replace it with that, or add a package for it? This
-# tool uses xorg headers (and maybe libraries) which is unfortunate.
-# http://stackoverflow.com/questions/6362705/replacing-makedepend-with-cc-mm
-# echo "echo \$*" > "${SRC_DIR}"/makedepend
-# echo "${CC} -M $(echo \"\$*\" | sed s'# --##g')" >> "${SRC_DIR}"/makedepend
-# chmod +x "${SRC_DIR}"/makedepend
-# PATH=${SRC_DIR}:${PATH} make -j1 depend
+# If build with additional debug flags are needed (e.g. for investigating
+# ABI compatibility with abi-dumper), uncomment:
+# CFLAGS="${CFLAGS} -Og -g"
+CC="${CC}" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
+  ${_CONFIGURATOR} "${_CONFIG_OPTS[@]}"
 
 make -j${CPU_COUNT}
-
-# expected error: https://github.com/openssl/openssl/issues/6953
-#    OK to ignore: https://github.com/openssl/openssl/issues/6953#issuecomment-415428340
-rm test/recipes/04-test_err.t
-
-# When testing this via QEMU, even though it ends printing:
-# "ALL TESTS SUCCESSFUL."
-# .. it exits with a failure code.
-if [[ "${HOST}" == "${BUILD}" ]]; then
-  # Using verbosity on failed (sub-)tests only VF=1
-  make test V=1 > testsuite.log 2>&1 || true
-  
-  if ! cat testsuite.log | grep -i "all tests successful"; then
-    echo "Testsuite failed!  See $(pwd)/testsuite.log for more info."
-    cat $(pwd)/testsuite.log
-    exit 1
-  fi
-fi
-make install_sw install_ssldirs
-
-# https://github.com/ContinuumIO/anaconda-issues/issues/6424
-if [[ ${HOST} =~ .*linux.* ]]; then
-  if execstack -q "${PREFIX}"/lib/libcrypto.so.3.0 | grep -e '^X '; then
-    echo "Error, executable stack found in libcrypto.so.3.0"
-    exit 1
-  fi
-fi
+make test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,6 +26,9 @@ _CONFIG_OPTS+=(enable-legacy)
 # With no-module, the legacy provider is built into libcrypto.
 _CONFIG_OPTS+=(no-module)
 
+# Ensure that shared libraries are built
+_CONFIG_OPTS+=(shared)
+
 if [[ "$target_platform" = "linux-"* ]]; then
   # KTLS is an optimization feature for Linux (and FreeBSD)
   _CONFIG_OPTS+=(enable-ktls)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -63,4 +63,5 @@ CC="${CC}" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
   ${_CONFIGURATOR} "${_CONFIG_OPTS[@]}"
 
 make -j${CPU_COUNT}
+make install
 make test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,10 +26,6 @@ _CONFIG_OPTS+=(enable-legacy)
 # With no-module, the legacy provider is built into libcrypto.
 _CONFIG_OPTS+=(no-module)
 
-# CF provides shared libraries in a separate output.
-# Since we don't do it, optimize build process by disabling it.
-_CONFIG_OPTS+=(no-shared)
-
 if [[ "$target_platform" = "linux-"* ]]; then
   # KTLS is an optimization feature for Linux (and FreeBSD)
   _CONFIG_OPTS+=(enable-ktls)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -66,6 +66,12 @@ esac
 CC="${CC}" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
   ${_CONFIGURATOR} "${_CONFIG_OPTS[@]}"
 
+# Specify in metadata where the packaging is coming from
+export OPENSSL_VERSION_BUILD_METADATA="+anaconda"
+
+# Dump configuration results
+perl configdata.pm --dump
+
 make -j${CPU_COUNT}
 make test
 make install_sw install_ssldirs

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,14 +30,19 @@ _CONFIG_OPTS+=(no-module)
 # Since we don't do it, optimize build process by disabling it.
 _CONFIG_OPTS+=(no-shared)
 
-# In previous versions of build.sh, no-ssl2 and no-ssl3 were also added.
-# However, ssl2 was removed in OpenSSL 1.1.0 and ssl3 is disabled by default.
-# CF ignores 'fips' but it's off by default anyway.
-
 if [[ "$target_platform" = "linux-"* ]]; then
   # KTLS is an optimization feature for Linux (and FreeBSD)
   _CONFIG_OPTS+=(enable-ktls)
 fi
+
+# NOTE 1: In previous versions of build.sh, no-ssl2 and no-ssl3 were also added.
+#   However, ssl2 was removed in OpenSSL 1.1.0 and ssl3 is disabled by default.
+# NOTE 2: CF ignores 'fips' but it's off by default anyway.
+# NOTE 3: We do not set --openssldir here (unlike Windows in bld.bat). On Unix, conda
+#   performs prefix replacement in binaries, so the default OPENSSLDIR (under
+#   prefix) is rewritten at install time and the package's ssl dir is used.  The
+#   env is user-owned, so the engine-injection risk that motivates a read-only
+#   OPENSSLDIR on Windows does not apply.
 
 # Do not allow config to make any guesses based on uname.
 # Target names can be found in upstream at Configurations/10-main.conf
@@ -63,5 +68,5 @@ CC="${CC}" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}" \
   ${_CONFIGURATOR} "${_CONFIG_OPTS[@]}"
 
 make -j${CPU_COUNT}
-make install
 make test
+make install

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,5 +1,5 @@
 @echo off
-if "%__CONDA_OPENSLL_CERT_FILE_SET%" == "1" (
+if "%__CONDA_OPENSSL_CERT_FILE_SET%" == "1" (
     set SSL_CERT_FILE=
-    set __CONDA_OPENSLL_CERT_FILE_SET=
+    set __CONDA_OPENSSL_CERT_FILE_SET=
 )

--- a/recipe/deactivate.ps1
+++ b/recipe/deactivate.ps1
@@ -1,4 +1,4 @@
-if ($Env:__CONDA_OPENSLL_CERT_FILE_SET -eq "1") {
+if ($Env:__CONDA_OPENSSL_CERT_FILE_SET -eq "1") {
     Remove-Item -Path Env:\SSL_CERT_FILE
-    Remove-Item -Path Env:\__CONDA_OPENSLL_CERT_FILE_SET
+    Remove-Item -Path Env:\__CONDA_OPENSSL_CERT_FILE_SET
 }

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,4 +1,4 @@
-if [[ "${__CONDA_OPENSLL_CERT_FILE_SET:-}" == "1" ]]; then
+if [[ "${__CONDA_OPENSSL_CERT_FILE_SET:-}" == "1" ]]; then
     unset SSL_CERT_FILE
-    unset __CONDA_OPENSLL_CERT_FILE_SET
+    unset __CONDA_OPENSSL_CERT_FILE_SET
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,10 @@ test:
     # test pkgconfig metadata
     - pkg-config --print-errors --exact-version "{{ version }}" openssl
     # test presence of most important files
-    - test -f ${PREFIX}/lib/libcrypto.{SHLIB_EXT}                    # [unix]
-    - test -f ${PREFIX}/lib/libssl.{SHLIB_EXT}                       # [unix]
+    - test -f ${PREFIX}/lib/libcrypto.so.3                           # [linux]
+    - test -f ${PREFIX}/lib/libssl.so.3                              # [linux]
+    - test -f ${PREFIX}/lib/libcrypto.3.dylib                        # [osx]
+    - test -f ${PREFIX}/lib/libssl.3.dylib                           # [osx]
     - test -f ${PREFIX}/lib/pkgconfig/libssl.pc                      # [unix]
     - test -f ${PREFIX}/lib/pkgconfig/libcrypto.pc                   # [unix]
     - test -f ${PREFIX}/lib/pkgconfig/openssl.pc                     # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,14 +63,14 @@ test:
     - test -f ${PREFIX}/bin/openssl                                  # [unix]
     - test -f ${PREFIX}/bin/c_rehash                                 # [unix]
     - test -n "$(ls -A ${PREFIX}/include/openssl 2>/dev/null)"       # [unix]
-    # - if not exist "%LIBRARY_LIB%\lib\libcrypto.lib" exit 1           # [win]
-    # - if not exist "%LIBRARY_LIB%\lib\libssl.lib" exit 1              # [win]
-    # - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libssl.pc" exit 1     # [win]
-    # - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libcrypto.pc" exit 1  # [win]
-    # - if not exist "%LIBRARY_LIB%\lib\pkgconfig\openssl.pc" exit 1    # [win]
-    # - if not exist "%LIBRARY_LIB%\bin\openssl.exe" exit 1             # [win]
-    # - if not exist "%LIBRARY_LIB%\bin\c_rehash" exit 1                # [win]
-    # - if not exist "%LIBRARY_LIB%\include\openssl" exit 1             # [win]
+    - if not exist "%LIBRARY_LIB%\libcrypto.lib" exit 1              # [win]
+    - if not exist "%LIBRARY_LIB%\libssl.lib" exit 1                 # [win]
+    - if not exist "%LIBRARY_LIB%\pkgconfig\libssl.pc" exit 1        # [win]
+    - if not exist "%LIBRARY_LIB%\pkgconfig\libcrypto.pc" exit 1     # [win]
+    - if not exist "%LIBRARY_LIB%\pkgconfig\openssl.pc" exit 1       # [win]
+    - if not exist "%LIBRARY_BIN%\openssl.exe" exit 1                # [win]
+    - if not exist "%LIBRARY_BIN%\c_rehash" exit 1                   # [win]
+    - if not exist "%LIBRARY_INC%\openssl" exit 1                    # [win]
 
 about:
   home: https://www.openssl.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - openssl ecparam -name prime256v1
     - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
     - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
-    # - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
+    - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata
     - pkg-config --print-errors --exact-version "{{ version }}" openssl
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,6 @@ test:
     - if not exist "%LIBRARY_LIB%\pkgconfig\libcrypto.pc" exit 1     # [win]
     - if not exist "%LIBRARY_LIB%\pkgconfig\openssl.pc" exit 1       # [win]
     - if not exist "%LIBRARY_BIN%\openssl.exe" exit 1                # [win]
-    - if not exist "%LIBRARY_BIN%\c_rehash" exit 1                   # [win]
     - if not exist "%LIBRARY_INC%\openssl" exit 1                    # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,8 @@ build:
     - lib/pkgconfig/openssl.pc           # [unix]
   detect_binary_files_with_prefix: true
   binary_has_prefix_files:               # [unix]
-    - lib/libcrypto.a                    # [unix]
-    - bin/openssl                        # [unix]
+    - lib/libcrypto.so.3.0  # [linux]
+    - lib/libcrypto.3.dylib  # [osx]
   run_exports:
     # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev))
     # https://openssl-library.org/policies/releasestrat/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.0.19" %}
+{% set version = "3.5.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072
+  sha256: b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - touch checksum.txt           # [unix]
     - openssl sha256 checksum.txt
     - openssl ecparam -name prime256v1
-    - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
+    - if not defined SSL_CERT_FILE exit 1  # [win]
     - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
     - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,19 @@ source:
   sha256: b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
 build:
   number: 0
+  # Prefix replacement: binaries and text files from the build contain the build
+  # prefix; these settings ensure conda rewrites them at install time (Unix).
+  # Windows uses a system path for OPENSSLDIR so no prefix in that path.
+  has_prefix_files:                      # [unix]
+    - bin/c_rehash                       # [unix]
+    - lib/pkgconfig/libcrypto.pc         # [unix]
+    - lib/pkgconfig/libssl.pc            # [unix]
+    - lib/pkgconfig/openssl.pc           # [unix]
+  detect_binary_files_with_prefix: true
+  binary_has_prefix_files:                # [unix]
+    - lib/libcrypto.a                    # [unix]
+    - lib/libssl.a                       # [unix]
+    - bin/openssl                        # [unix]
   run_exports:
     # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev)
     # https://www.openssl.org/policies/general/versioning-policy.html#minor-release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,14 +63,14 @@ test:
     - test -f ${PREFIX}/bin/openssl                                  # [unix]
     - test -f ${PREFIX}/bin/c_rehash                                 # [unix]
     - test -n "$(ls -A ${PREFIX}/include/openssl 2>/dev/null)"       # [unix]
-    - if not exist %LIBRARY_LIB%\lib\libcrypto.lib" exit 1           # [win]
-    - if not exist %LIBRARY_LIB%\lib\libssl.lib" exit 1              # [win]
-    - if not exist %LIBRARY_LIB%\lib\pkgconfig\libssl.pc" exit 1     # [win]
-    - if not exist %LIBRARY_LIB%\lib\pkgconfig\libcrypto.pc" exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\lib\pkgconfig\openssl.pc" exit 1    # [win]
-    - if not exist %LIBRARY_LIB%\bin\openssl.exe" exit 1             # [win]
-    - if not exist %LIBRARY_LIB%\bin\c_rehash" exit 1                # [win]
-    - if not exist %LIBRARY_LIB%\include\openssl" exit 1             # [win]
+    - if not exist "%LIBRARY_LIB%\lib\libcrypto.lib" exit 1           # [win]
+    - if not exist "%LIBRARY_LIB%\lib\libssl.lib" exit 1              # [win]
+    - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libssl.pc" exit 1     # [win]
+    - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libcrypto.pc" exit 1  # [win]
+    - if not exist "%LIBRARY_LIB%\lib\pkgconfig\openssl.pc" exit 1    # [win]
+    - if not exist "%LIBRARY_LIB%\bin\openssl.exe" exit 1             # [win]
+    - if not exist "%LIBRARY_LIB%\bin\c_rehash" exit 1                # [win]
+    - if not exist "%LIBRARY_LIB%\include\openssl" exit 1             # [win]
 
 about:
   home: https://www.openssl.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,13 @@ build:
     - lib/pkgconfig/libssl.pc            # [unix]
     - lib/pkgconfig/openssl.pc           # [unix]
   detect_binary_files_with_prefix: true
-  binary_has_prefix_files:                # [unix]
+  binary_has_prefix_files:               # [unix]
     - lib/libcrypto.a                    # [unix]
-    - lib/libssl.a                       # [unix]
     - bin/openssl                        # [unix]
   run_exports:
-    # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev)
-    # https://www.openssl.org/policies/general/versioning-policy.html#minor-release
-    #    This pin allows the patch release to be >= the build-time openssl version.
+    # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev))
+    # https://openssl-library.org/policies/releasestrat/
+    # This pin allows the patch release to be >= the build-time openssl version.
     - {{ pin_subpackage('openssl', max_pin='x') }}
 
 requirements:
@@ -41,7 +40,7 @@ requirements:
 
 test:
   requires:
-    - python 3.9
+    - python 3.13
     - pkg-config
   commands:
     - copy NUL checksum.txt        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,12 +43,12 @@ test:
     - python 3.13
     - pkg-config
   commands:
-    # - copy NUL checksum.txt        # [win]
+    - copy NUL checksum.txt        # [win]
     - touch checksum.txt           # [unix]
-    # - openssl sha256 checksum.txt
-    # - openssl ecparam -name prime256v1
-    # - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
-    # - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
+    - openssl sha256 checksum.txt
+    - openssl ecparam -name prime256v1
+    - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
+    - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
     - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata
     - pkg-config --print-errors --exact-version "{{ version }}" openssl
@@ -63,14 +63,14 @@ test:
     - test -f ${PREFIX}/bin/openssl                                  # [unix]
     - test -f ${PREFIX}/bin/c_rehash                                 # [unix]
     - test -n "$(ls -A ${PREFIX}/include/openssl 2>/dev/null)"       # [unix]
-    - if not exist "%LIBRARY_LIB%\lib\libcrypto.lib" exit 1           # [win]
-    - if not exist "%LIBRARY_LIB%\lib\libssl.lib" exit 1              # [win]
-    - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libssl.pc" exit 1     # [win]
-    - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libcrypto.pc" exit 1  # [win]
-    - if not exist "%LIBRARY_LIB%\lib\pkgconfig\openssl.pc" exit 1    # [win]
-    - if not exist "%LIBRARY_LIB%\bin\openssl.exe" exit 1             # [win]
-    - if not exist "%LIBRARY_LIB%\bin\c_rehash" exit 1                # [win]
-    - if not exist "%LIBRARY_LIB%\include\openssl" exit 1             # [win]
+    # - if not exist "%LIBRARY_LIB%\lib\libcrypto.lib" exit 1           # [win]
+    # - if not exist "%LIBRARY_LIB%\lib\libssl.lib" exit 1              # [win]
+    # - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libssl.pc" exit 1     # [win]
+    # - if not exist "%LIBRARY_LIB%\lib\pkgconfig\libcrypto.pc" exit 1  # [win]
+    # - if not exist "%LIBRARY_LIB%\lib\pkgconfig\openssl.pc" exit 1    # [win]
+    # - if not exist "%LIBRARY_LIB%\bin\openssl.exe" exit 1             # [win]
+    # - if not exist "%LIBRARY_LIB%\bin\c_rehash" exit 1                # [win]
+    # - if not exist "%LIBRARY_LIB%\include\openssl" exit 1             # [win]
 
 about:
   home: https://www.openssl.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - touch checksum.txt           # [unix]
     - openssl sha256 checksum.txt
     - openssl ecparam -name prime256v1
-    - if not defined SSL_CERT_FILE exit 1  # [win]
+    - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
     - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
     - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,15 @@ build:
   # Prefix replacement: binaries and text files from the build contain the build
   # prefix; these settings ensure conda rewrites them at install time (Unix).
   # Windows uses a system path for OPENSSLDIR so no prefix in that path.
-  has_prefix_files:                      # [unix]
-    - bin/c_rehash                       # [unix]
-    - lib/pkgconfig/libcrypto.pc         # [unix]
-    - lib/pkgconfig/libssl.pc            # [unix]
-    - lib/pkgconfig/openssl.pc           # [unix]
-  detect_binary_files_with_prefix: true
-  binary_has_prefix_files:               # [unix]
-    - lib/libcrypto.so.3.0  # [linux]
-    - lib/libcrypto.3.dylib  # [osx]
+  # has_prefix_files:                      # [unix]
+  #   - bin/c_rehash                       # [unix]
+  #   - lib/pkgconfig/libcrypto.pc         # [unix]
+  #   - lib/pkgconfig/libssl.pc            # [unix]
+  #   - lib/pkgconfig/openssl.pc           # [unix]
+  # detect_binary_files_with_prefix: true
+  # binary_has_prefix_files:               # [unix]
+  #   - lib/libcrypto.so.3     # [linux]
+  #   - lib/libcrypto.3.dylib  # [osx]
   run_exports:
     # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev))
     # https://openssl-library.org/policies/releasestrat/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,15 @@ build:
   # Prefix replacement: binaries and text files from the build contain the build
   # prefix; these settings ensure conda rewrites them at install time (Unix).
   # Windows uses a system path for OPENSSLDIR so no prefix in that path.
-  # has_prefix_files:                      # [unix]
-  #   - bin/c_rehash                       # [unix]
-  #   - lib/pkgconfig/libcrypto.pc         # [unix]
-  #   - lib/pkgconfig/libssl.pc            # [unix]
-  #   - lib/pkgconfig/openssl.pc           # [unix]
-  # detect_binary_files_with_prefix: true
-  # binary_has_prefix_files:               # [unix]
-  #   - lib/libcrypto.so.3     # [linux]
-  #   - lib/libcrypto.3.dylib  # [osx]
+  has_prefix_files:                      # [unix]
+    - bin/c_rehash                       # [unix]
+    - lib/pkgconfig/libcrypto.pc         # [unix]
+    - lib/pkgconfig/libssl.pc            # [unix]
+    - lib/pkgconfig/openssl.pc           # [unix]
+  detect_binary_files_with_prefix: true
+  binary_has_prefix_files:               # [unix]
+    - lib/libcrypto.so.3     # [linux]
+    - lib/libcrypto.3.dylib  # [osx]
   run_exports:
     # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev))
     # https://openssl-library.org/policies/releasestrat/
@@ -52,6 +52,23 @@ test:
     - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata
     - pkg-config --print-errors --exact-version "{{ version }}" openssl
+    # test presence of most important files
+    - test -f ${PREFIX}/lib/libcrypto.{SHLIB_EXT}                    # [unix]
+    - test -f ${PREFIX}/lib/libssl.{SHLIB_EXT}                       # [unix]
+    - test -f ${PREFIX}/lib/pkgconfig/libssl.pc                      # [unix]
+    - test -f ${PREFIX}/lib/pkgconfig/libcrypto.pc                   # [unix]
+    - test -f ${PREFIX}/lib/pkgconfig/openssl.pc                     # [unix]
+    - test -f ${PREFIX}/bin/openssl                                  # [unix]
+    - test -f ${PREFIX}/bin/c_rehash                                 # [unix]
+    - test -n "$(ls -A ${PREFIX}/include/openssl 2>/dev/null)"       # [unix]
+    - if not exist %LIBRARY_LIB%\lib\libcrypto.lib" exit 1           # [win]
+    - if not exist %LIBRARY_LIB%\lib\libssl.lib" exit 1              # [win]
+    - if not exist %LIBRARY_LIB%\lib\pkgconfig\libssl.pc" exit 1     # [win]
+    - if not exist %LIBRARY_LIB%\lib\pkgconfig\libcrypto.pc" exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\lib\pkgconfig\openssl.pc" exit 1    # [win]
+    - if not exist %LIBRARY_LIB%\bin\openssl.exe" exit 1             # [win]
+    - if not exist %LIBRARY_LIB%\bin\c_rehash" exit 1                # [win]
+    - if not exist %LIBRARY_LIB%\include\openssl" exit 1             # [win]
 
 about:
   home: https://www.openssl.org
@@ -66,7 +83,7 @@ about:
     on a full-strength general purpose cryptographic library, which can also
     be used stand-alone.
   dev_url: https://github.com/openssl/openssl
-  doc_url: https://www.openssl.org/docs/man3.0
+  doc_url: https://docs.openssl.org
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   sha256: b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
 build:
   number: 0
+  no_link: lib/libcrypto.so.3.0        # [linux]
+  no_link: lib/libcrypto.3.0.dylib     # [osx]
   # Prefix replacement: binaries and text files from the build contain the build
   # prefix; these settings ensure conda rewrites them at install time (Unix).
   # Windows uses a system path for OPENSSLDIR so no prefix in that path.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,12 +43,12 @@ test:
     - python 3.13
     - pkg-config
   commands:
-    - copy NUL checksum.txt        # [win]
+    # - copy NUL checksum.txt        # [win]
     - touch checksum.txt           # [unix]
-    - openssl sha256 checksum.txt
-    - openssl ecparam -name prime256v1
-    - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
-    - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
+    # - openssl sha256 checksum.txt
+    # - openssl ecparam -name prime256v1
+    # - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
+    # - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
     - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata
     - pkg-config --print-errors --exact-version "{{ version }}" openssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
 build:
   number: 0
-  no_link: lib/libcrypto.so.3.0        # [linux]
-  no_link: lib/libcrypto.3.0.dylib     # [osx]
+  no_link:
+    - lib/libcrypto.so.3.0        # [linux]
+    - lib/libcrypto.3.0.dylib     # [osx]
   # Prefix replacement: binaries and text files from the build contain the build
   # prefix; these settings ensure conda rewrites them at install time (Unix).
   # Windows uses a system path for OPENSSLDIR so no prefix in that path.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,23 +10,11 @@ source:
   sha256: b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
 build:
   number: 0
-  no_link: lib/libcrypto.so.3.0        # [linux]
-  no_link: lib/libcrypto.3.0.dylib     # [osx]
-  has_prefix_files:                      # [unix]
-    - bin/c_rehash                       # [unix]
-    - lib/pkgconfig/libcrypto.pc         # [unix]
-    - lib/pkgconfig/libssl.pc            # [unix]
-    - lib/pkgconfig/openssl.pc           # [unix]
   run_exports:
     # openssl's versioning of starting with 3.0 is X.Y.Z  (1.x was X.Y.Z(rev)
     # https://www.openssl.org/policies/general/versioning-policy.html#minor-release
     #    This pin allows the patch release to be >= the build-time openssl version.
     - {{ pin_subpackage('openssl', max_pin='x') }}
-  detect_binary_files_with_prefix: True
-  binary_has_prefix_files:
-    - lib/libcrypto.so.3.0  # [linux]
-    - lib/libcrypto.3.0.dylib  # [osx]
-    - lib/libcrypto.a  # [unix]
 
 requirements:
   build:
@@ -49,7 +37,7 @@ test:
     - openssl ecparam -name prime256v1
     - if "%SSL_CERT_FILE%"=="" exit 1  # [win]
     - if not exist "%SSL_CERT_FILE%" exit 1  # [win]
-    - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
+    # - python -c "import urllib.request; urllib.request.urlopen('https://pypi.org')"
     # test pkgconfig metadata
     - pkg-config --print-errors --exact-version "{{ version }}" openssl
 


### PR DESCRIPTION
openssl 3.5.5

**Destination channel:** Defaults

### Links

- [PKG-9917](https://anaconda.atlassian.net/browse/PKG-9917)
- dev_url: https://github.com/openssl/openssl/tree/openssl-3.5.5
- conda_forge: https://github.com/conda-forge/openssl-feedstock
- latest version of 3.5.x on conda_forge: https://github.com/conda-forge/openssl-feedstock/commit/c8d762864846b867fc26602c7ac99a8ba98da5bc

### Explanation of changes:

- new version number
- full rework on _build.sh_ script:
  - Each specified option is justified with comment
  - Build options review - synced with conda-forge
  - Delete depracated/old/unsupported/not up-to-dated stuff
- sync _bld.bat_ with _build.sh_
- add more testing to recipe
- fix linter problems

# NOTES

## 1. Why not 3.6?

3.5 version is an LTS release: https://openssl-library.org/post/2025-04-08-openssl-35-final-release/

## 2. What was deleted/changed/added?

- `engines-3` deprecated from version 3.0. `lib/engines-3/*.so` are not a part of conda package anymore. This addresses: https://github.com/AnacondaRecipes/openssl-feedstock/pull/35#issuecomment-3822797792
- `lib/ossl-modules/legacy.so` is not present in conda package anymore. The content of this library is now embedded in `libcrypto` through `_CONFIG_OPTS+=(no-module)` build option
- `enable-ktls` added for linux. Conda-forge adds it as well
- deleted some options that are set by default anyway or leave these that increases explicitness (like `enable-legacy`)
- delete cross-compiling artifacts of past
- add comments with related CVEs or issues to justify options taken during build
- the build now adds automatically _cmake_ files

## 3. Considerations

1. Was deleting `engines-3` safe in case of legacy? - _yes_, especially for security reasons. Can be added separately by providers: https://github.com/openssl/openssl/blob/openssl-3.0.19/README-ENGINES.md
2. Is moving `lib/ossl-modules/legacy.so` to `libcrypto` safe during potential rebuilds for older downstreams? - most probably _yes_ but could require build process tweaks
3. Does it make sense to support _pkg-config_ files since _cmake_ files are present now? - probably _yes_ for rebuild convenience, but moving to _cmake_ in downstreams should be strongly considered
4. Does it make sense to keep `no_link`, `has_prefix_files`, `detect_binary_files_with_prefix` and `binary_has_prefix_files`? After all, conda-forge doesn't do that - _maybe_, even though without some of these options doesn't really affect libraries when investigating with `readelf`
5. Speaking of `no_link` - does it make sense to add Windows library? That could fix occurring problem with `conda update -n base -c defaults conda` on Windows with _FileExistsError_ `unlink_or_rename_to_trash libcrypto-3-x64.dll.c~`
6. Are `activate` script still needed? - for Windows _maybe_, for Unix not so sure
7. Is specifying in Windows build config `--openssldir="%CommonProgramFiles%\ssl"` still a good idea? That was the approach taken long time ago. Maybe there's a more modern way to manage the security concern behind it?


[PKG-9917]: https://anaconda.atlassian.net/browse/PKG-9917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ