### PR TITLE
openssl 3.5.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.5.5" %}
+{% set version = "3.5.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
+  sha256: deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736
 build:
   number: 0
   no_link:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13471](https://anaconda.atlassian.net/browse/PKG-13471)
- [Upstream repository](https://github.com/openssl/openssl/tree/openssl-3.5.6)
- [Upstream changelog/diff](https://github.com/openssl/openssl/blob/openssl-3.5.6/CHANGES.md)

### Explanation of changes:

- Bump version number
- Fixes https://www.cve.org/CVERecord?id=CVE-2026-2673

[PKG-13471]: https://anaconda.atlassian.net/browse/PKG-13471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ