### PR TITLE
openssl 3.0.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.0.19" %}
+{% set version = "3.0.20" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072
+  sha256: c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13472](https://anaconda.atlassian.net/browse/PKG-13472)
- [Upstream repository](https://github.com/openssl/openssl/tree/openssl-3.0.20)
- [Upstream changelog/diff](https://github.com/openssl/openssl/blob/openssl-3.0.20/CHANGES.md)

### Explanation of changes:

- Bump version number
- https://github.com/openssl/openssl/discussions/30702


[PKG-13472]: https://anaconda.atlassian.net/browse/PKG-13472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ