### PR TITLE
3.5.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.5.6" %}
+{% set version = "3.5.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736
+  sha256: a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8
 build:
   number: 0
   no_link:


### PR DESCRIPTION
openssl 3.5.7

**Destination channel:** defaults

### Links

- [PKG-15265](https://anaconda.atlassian.net/browse/PKG-15265) 
- [Upstream repository](https://github.com/openssl/openssl/tree/openssl-3.5.7)
- [Upstream changelog/diff](https://github.com/openssl/openssl/compare/openssl-3.5.6...openssl-3.5.7)
- Relevant dependency PRs:
  - [arrow-cpp](https://github.com/AnacondaRecipes/arrow-cpp-feedstock/pull/66)
  - [dotnet](https://github.com/AnacondaRecipes/dotnet-feedstock/pull/4)
  - [ldid](https://github.com/AnacondaRecipes/ldid-feedstock/pull/6)
  - [serf](https://github.com/AnacondaRecipes/serf-feedstock/pull/4)

### Explanation of changes:

- Bump version and SHA


[PKG-15265]: https://anaconda.atlassian.net/browse/PKG-15265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ