### PR TITLE
v3.0.21

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/pbp/fs/python-feedstock/pr225/67916e8
+  - https://staging.continuum.io/pbp/fs/python-feedstock/pr226/4bb403b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/python-feedstock/pr226/4bb403b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/python-feedstock/pr225/67916e8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,13 @@ requirements:
     - perl {{ perl }}
   run:
     - ca-certificates
+  run_constrained:
+    # Previous versions of python weren't patched for https://github.com/python/cpython/pull/100373
+    - python >=3.10
 
 test:
   requires:
-    - python 3.9
+    - python 3.10
     - pkg-config
   commands:
     - copy NUL checksum.txt        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openssl" %}
-{% set version = "3.0.20" %}
+{% set version = "3.0.21" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f
+  sha256: 617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f
 build:
   number: 0
   no_link: lib/libcrypto.so.3.0        # [linux]


### PR DESCRIPTION
openssl 3.0.21

**Destination channel:** defaults

### Links

- [PKG-15292](https://anaconda.atlassian.net/browse/PKG-15292) 
- [Upstream repository](https://github.com/openssl/openssl/tree/openssl-3.0.21)
- [Upstream changelog/diff](https://github.com/openssl/openssl/releases/tag/openssl-3.0.21)


### Explanation of changes:

- Bump version and SHA


[PKG-15292]: https://anaconda.atlassian.net/browse/PKG-15292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ